### PR TITLE
Initial work

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,30 +8,87 @@ In the current version, `krux_ec2.ec2.EC2` is only compatible with `krux_boto.bo
 
 ## Application quick start
 
-The most common use case is to build a CLI script using `krux_boto.cli.Application`.
+The most common use case is to build a CLI script using `krux_ec2.cli.Application`.
 Here's how to do that:
 
 ```python
 
-from krux_boto.cli import Application
-from krux_ec2.ec2 import EC2
+import krux_ec2.cli
+from krux_ec2.filter import Filter
+
+# This class inherits from krux.cli.Application, so it provides
+# all that functionality as well.
+class Application(krux_ec2.cli.Application):
+    def run(self):
+        f = Filter({
+            'tag:Name': 'example.krxd.net',
+            'instance-state-name': ['running', 'stopped'],
+        })
+        print self.ec2.find_instances(f)
 
 def main():
-    # The name must be unique to the organization. The object
-    # returned inherits from krux.cli.Application, so it provides
-    # all that functionality as well.
-    app = Application(name='krux-my-boto-script')
+    # The name must be unique to the organization.
+    app = Application(name='krux-my-ec2-script')
+    with app.context():
+        app.run()
 
-    ec2 = EC2(boto=app.boto)
-    f = Filter({
-        'tag:Name': 'example.krxd.net',
-        'instance-state-name': ['running', 'stopped'],
-    })
-    print ec2.find_instances(f)
-
-### Run the application stand alone
+# Run the application stand alone
 if __name__ == '__main__':
     main()
+
+```
+
+## Extending your application
+
+From other CLI applications, you can make the use of `krux_ec2.ec2.get_ec2()` function.
+
+```python
+
+from krux_ec2.ec2 import add_ec2_cli_arguments, get_ec2
+import krux.cli
+
+class Application(krux.cli.Application):
+
+    def __init__(self, *args, **kwargs):
+        super(Application, self).__init__(*args, **kwargs)
+
+        self.ec2 = get_ec2(self.args, self.logger, self.stats)
+
+    def add_cli_arguments(self, parser):
+        super(Application, self).add_cli_arguments(parser)
+
+        add_ec2_cli_arguments(parser)
+
+```
+
+Alternately, you want to add S3 functionality to your larger script or application.
+Here's how to do that:
+
+```python
+
+from krux_boto import Boto
+from krux_ec2.ec2 import EC2
+from krux_ec2.filter import Filter
+
+class MyApplication(object):
+
+    def __init__(self, *args, **kwargs):
+        boto = Boto(
+            logger=self.logger,
+            stats=self.stats,
+        )
+        self.ec2 = EC2(
+            boto=boto,
+            logger=self.logger,
+            stats=self.stats,
+        )
+
+    def run(self):
+        f = Filter({
+            'tag:Name': 'example.krxd.net',
+            'instance-state-name': ['running', 'stopped'],
+        })
+        print self.ec2.find_instances(f)
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
 # krux_ec2
+
+`krux_ec2` is a library that provides wrapper functions for common EC2 usage. It uses `krux_boto` to connect to AWS EC2.
+
+## Warning
+
+In the current version, `krux_ec2.ec2.EC2` is only compatible with `krux_boto.boto.Boto` object. Passing other objects, such as `krux_boto.boto.Boto3`, will cause an exception.
+
+## Application quick start
+
+The most common use case is to build a CLI script using `krux_boto.cli.Application`.
+Here's how to do that:
+
+```python
+
+from krux_boto.cli import Application
+from krux_ec2.ec2 import EC2
+
+def main():
+    # The name must be unique to the organization. The object
+    # returned inherits from krux.cli.Application, so it provides
+    # all that functionality as well.
+    app = Application(name='krux-my-boto-script')
+
+    ec2 = EC2(boto=app.boto)
+    f = Filter({
+        'tag:Name': 'example.krxd.net',
+        'instance-state-name': ['running', 'stopped'],
+    })
+    print ec2.find_instances(f)
+
+### Run the application stand alone
+if __name__ == '__main__':
+    main()
+
+```
+
+As long as you get an instance of `krux_boto.boto.Boto`, the rest are the same. Refer to `krux_boto` module's [README](https://github.com/krux/python-krux-boto/blob/master/README.md) on various ways to instanciate the class.

--- a/krux_ec2/cli.py
+++ b/krux_ec2/cli.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+#
+# © 2016 Krux Digital, Inc.
+#
+
+#
+# Standard libraries
+#
+
+from __future__ import absolute_import
+import os
+
+#
+# Internal libraries
+#
+
+from krux.cli import get_group
+import krux_boto.cli
+from krux_ec2.ec2 import add_ec2_cli_arguments, get_ec2, NAME
+from krux_ec2.filter import Filter
+
+
+class Application(krux_boto.cli.Application):
+
+    def __init__(self, name=NAME):
+        # Call to the superclass to bootstrap.
+        super(Application, self).__init__(name=name)
+
+        self.ec2 = get_ec2(self.args, self.logger, self.stats)
+
+    def add_cli_arguments(self, parser):
+        # Call to the superclass
+        super(Application, self).add_cli_arguments(parser)
+
+        add_ec2_cli_arguments(parser, include_boto_arguments=False)
+
+    def run(self):
+        f = Filter({
+            'tag:Name': 'cc001.krxd.net',
+            'instance-state-name': ['running', 'stopped'],
+        })
+        print self.ec2.find_instances(f)
+
+
+def main():
+    app = Application()
+    with app.context():
+        app.run()
+
+
+# Run the application stand alone
+if __name__ == '__main__':
+    main()

--- a/krux_ec2/ec2.py
+++ b/krux_ec2/ec2.py
@@ -3,9 +3,6 @@
 # © 2015 Krux Digital, Inc.
 #
 
-# TODO: This is currently inside krux_manage_instance library.
-# However, consider breaking this into a separate library or add it to krux_boto library.
-
 #
 # Standard libraries
 #

--- a/krux_ec2/ec2.py
+++ b/krux_ec2/ec2.py
@@ -128,7 +128,7 @@ class EC2(object):
 
     def _get_connection(self):
         """
-        Returns a connection to the designated relsgion (self.boto.cli_region).
+        Returns a connection to the designated region (self.boto.cli_region).
         The connection is established on the first call for this instance (lazy) and cached.
         """
         if self._conn is None:

--- a/krux_ec2/ec2.py
+++ b/krux_ec2/ec2.py
@@ -118,6 +118,7 @@ class EC2(object):
         self._stats = stats or get_stats(prefix=self._name)
 
         # Throw exception when Boto2 is not used
+        # TODO: Start using Boto3 and reverse this check
         if not isinstance(boto, Boto):
             raise TypeError('krux_ec2.ec2.EC2 only supports krux_boto.boto.Boto')
 

--- a/krux_ec2/ec2.py
+++ b/krux_ec2/ec2.py
@@ -72,30 +72,27 @@ class EC2(object):
 
     def __init__(
         self,
+        boto,
         logger=None,
         stats=None,
-        parser=None,
     ):
         # Private variables, not to be used outside this module
         self._name = NAME
         self._logger = logger or get_logger(self._name)
         self._stats = stats or get_stats(prefix=self._name)
-        self._parser = parser or get_parser(description=self._name)
-        self._args = self._parser.parse_args()
 
-        # Add the boto connector
-        self.boto = Boto(
-            parser=self._parser,
-            logger=self._logger,
-            stats=self._stats,
-        )
+        # Throw exception when Boto2 is not used
+        if not isinstance(boto, Boto):
+            raise TypeError('krux_ec2.ec2.EC2 only supports krux_boto.boto.Boto')
+
+        self.boto = boto
 
         # Set up default cache
         self._conn = None
 
     def _get_connection(self):
         """
-        Returns a connection to the designated region (self.boto.cli_region).
+        Returns a connection to the designated relsgion (self.boto.cli_region).
         The connection is established on the first call for this instance (lazy) and cached.
         """
         if self._conn is None:

--- a/krux_ec2/ec2.py
+++ b/krux_ec2/ec2.py
@@ -1,0 +1,296 @@
+# -*- coding: utf-8 -*-
+#
+# © 2015 Krux Digital, Inc.
+#
+
+# TODO: This is currently inside krux_manage_instance library.
+# However, consider breaking this into a separate library or add it to krux_boto library.
+
+#
+# Standard libraries
+#
+
+from __future__ import absolute_import
+from pprint import pprint
+import re
+import time
+
+#
+# Third party libraries
+#
+
+import boto.ec2
+from boto.ec2.blockdevicemapping import BlockDeviceType, BlockDeviceMapping
+from retrying import retry
+
+#
+# Internal libraries
+#
+
+from krux_boto import Boto, add_boto_cli_arguments
+from krux.logging import get_logger
+from krux.stats import get_stats
+from krux.cli import get_parser, get_group
+from krux_ec2.filter import Filter
+from krux_manage_instance.spinner import Spinner
+
+
+NAME = 'krux-ec2'
+
+
+def add_ec2_cli_arguments(parser, include_boto_arguments=True):
+    """
+    Utility function for adding EC2 specific CLI arguments.
+    """
+    if include_boto_arguments:
+        # GOTCHA: Since EC2 and S3 both uses Boto, the Boto's CLI arguments can be included twice,
+        # causing an error. This creates a way to circumvent that.
+
+        # Add all the boto arguments
+        add_boto_cli_arguments(parser)
+
+    # Add those specific to the application
+    group = get_group(parser, NAME)
+
+
+class EC2(object):
+    """
+    A manager to handle all EC2 related functions.
+    Each instance is locked to a connection to a designated region (self.boto.cli_region).
+    """
+
+    # Timeout value in milliseconds for waiting for EC2 items to be ready
+    TIMEOUT = 120000  # 2 minutes
+
+    # Number of milliseconds to wait in between 2 checks
+    CHECK_INTERVAL = 3000  # 3 seconds
+
+    # This is the IAM role that the instance is started up with. The bootstrap
+    # role is needed so that bootstrap.py can update the instance's tags with
+    # its status.
+    INSTANCE_PROFILE_NAME = 'bootstrap'
+
+    def __init__(
+        self,
+        logger=None,
+        stats=None,
+        parser=None,
+    ):
+        # Private variables, not to be used outside this module
+        self._name = NAME
+        self._logger = logger or get_logger(self._name)
+        self._stats = stats or get_stats(prefix=self._name)
+        self._parser = parser or get_parser(description=self._name)
+        self._args = self._parser.parse_args()
+
+        # Add the boto connector
+        self.boto = Boto(
+            parser=self._parser,
+            logger=self._logger,
+            stats=self._stats,
+        )
+
+        # Set up default cache
+        self._conn = None
+
+    def _get_connection(self):
+        """
+        Returns a connection to the designated region (self.boto.cli_region).
+        The connection is established on the first call for this instance (lazy) and cached.
+        """
+        if self._conn is None:
+            self._conn = self.boto.ec2.connect_to_region(self.boto.cli_region)
+
+        return self._conn
+
+    @retry(
+        stop_max_delay=TIMEOUT,
+        wait_fixed=CHECK_INTERVAL,
+        # GOTCHA: Sometimes, the first few checks may be performed when the item is not ready.
+        # This causes an error. Ignore this error during this check.
+        retry_on_exception=lambda e: isinstance(e, boto.exception.EC2ResponseError),
+        retry_on_result=lambda r: not r
+    )
+    def _wait(self, item, check_func):
+        Spinner.next()
+        item.update()
+        return check_func(item)
+
+    def find_instances(self, search):
+        """
+        Returns a list of instances that matches the search criteria.
+
+        The search parameter must be either a krux_ec2.filter.Filter instance or
+        a dictionary or a list that krux_ec2.filter.Filter class can handle.
+        Refer to the docstring on the class.
+        """
+        instance_filter = None
+
+        if isinstance(search, list):
+            instance_filter = Filter()
+
+            for term in search:
+                instance_filter.parse_string(term)
+        elif isinstance(search, dict):
+            instance_filter = Filter(initial=search)
+        elif isinstance(search, Filter):
+            instance_filter = search
+        else:
+            raise NotImplementedError('This method cannot handle parameter of type {0}'.format(type(search).__name__))
+
+        self._logger.debug('Filters to use: %s', dict(instance_filter))
+
+        ec2 = self._get_connection()
+        instances = ec2.get_only_instances(filters=dict(instance_filter))
+
+        self._logger.info('Found following instances: %s', instances)
+
+        return instances
+
+    def run_instance(self, ami_id, cloud_config, instance_type, sec_group, zone):
+        """
+        Starts an instance in the given AMI.
+
+        The ami_id parameter is the ID of the AMI image where the new instance will be created.
+        The cloud_config parameter is passed as the user data.
+        The instance_type, sec_group, and zone are passed as respective parameters to AWS.
+
+        4 block devices are created as ephemeral and passed.
+        """
+        # OK, so, on larger instances, extra devices only show up if you tell them to associate with a block device.
+        # These EBS AMIs don't set this up, so we have to. sdb will always be ephemeral0,
+        # which is how we've always done it. If there are more devices, they will get sdc,sdd,sde.
+        # NOTE: see mounts.pp in kbase for how-we-deal-with-these.
+        block_device_map = BlockDeviceMapping()
+        sdb = BlockDeviceType()
+        sdc = BlockDeviceType()
+        sdd = BlockDeviceType()
+        sde = BlockDeviceType()
+        sdb.ephemeral_name = 'ephemeral0'
+        sdc.ephemeral_name = 'ephemeral1'
+        sdd.ephemeral_name = 'ephemeral2'
+        sde.ephemeral_name = 'ephemeral3'
+        block_device_map['/dev/sdb'] = sdb
+        block_device_map['/dev/sdc'] = sdc
+        block_device_map['/dev/sdd'] = sdd
+        block_device_map['/dev/sde'] = sde
+        # TODO: Focus attention during code review
+
+        ec2 = self._get_connection()
+        reservation = ec2.run_instances(
+            image_id=ami_id,
+            instance_type=instance_type,
+            user_data=cloud_config,
+            security_groups=[sec_group],
+            block_device_map=block_device_map,
+            instance_profile_name=self.INSTANCE_PROFILE_NAME,
+            placement=zone,
+        )
+
+        self._logger.debug('Started an instance in following reservation: %s', reservation)
+        self._logger.debug('Following instances are running on the reservation: %s', reservation.instances)
+
+        instance = reservation.instances[0]
+
+        self._logger.debug('Waiting for the instance to be ready...')
+        self._wait(instance, lambda instance: instance.state == 'running')
+
+        self._logger.info('Started instance %s', instance.public_dns_name)
+
+        return instance
+
+    def attach_ebs_volume(
+        self,
+        instance,
+        device,
+        save_on_termination,
+        volume_id=None,
+        volume_size=None,
+    ):
+        """
+        Attach a designated EBS volume to the given instance at the given device.
+
+        If volume_id parameter is provided, the corresponding EBS volume is attached.
+        If not, a new volume with the give volume_size is created and attached.
+        Either volume_id parameter or volume_size parameter is required.
+
+        If save_on_termination parameter is true, then the EBS volume is saved (not deleted)
+        upon the instance termination.
+        """
+        volume = None
+
+        ec2 = self._get_connection()
+        if volume_id is not None:
+            # GOTCHA: volume_id takes priority over volume_size
+            volume = ec2.create_volume(volume_ids=[volume_id])[0]
+        elif volume_size is not None:
+            volume = ec2.create_volume(volume_size, instance.placement)
+
+            self._logger.debug('Waiting for the EBS volume to be ready...')
+            self._wait(volume, lambda volume: volume.status == 'available')
+        else:
+            raise ValueError('Either volume_id or volume_size is required')
+
+        volume.attach(instance.id, device)
+
+        self._logger.debug('Waiting for the EBS volume to be attached...')
+        self._wait(volume, lambda volume: volume.attachment_state() == 'attached')
+
+        if not save_on_termination:
+            instance.modify_attribute('blockDeviceMapping', {device: True})
+
+        self._logger.info(
+            'Attached EBS volume %s to instance %s at %s',
+            volume.id, instance.public_dns_name, device
+        )
+
+        return volume
+
+    def find_ebs_volumes(self, search):
+        """
+        Returns a list of EBS volumes that matches the search criteria.
+
+        The search parameter must be either a krux_ec2.filter.Filter instance or
+        a dictionary or a list that krux_ec2.filter.Filter class can handle.
+        Refer to the docstring on the class.
+        """
+        ebs_filter = None
+
+        if isinstance(search, list):
+            ebs_filter = Filter()
+
+            for term in search:
+                ebs_filter.parse_string(term)
+        elif isinstance(search, dict):
+            ebs_filter = Filter(initial=search)
+        elif isinstance(search, Filter):
+            ebs_filter = search
+        else:
+            raise NotImplementedError('This method cannot handle parameter of type {0}'.format(type(search).__name__))
+
+        self._logger.debug('Filters to use: %s', dict(ebs_filter))
+
+        ec2 = self._get_connection()
+        volumes = ec2.get_all_volumes(filters=dict(ebs_filter))
+
+        self._logger.info('Found following volumes: %s', volumes)
+
+        return volumes
+
+    def find_security_group(self, security_group):
+        """
+        Returns a list of security groups with the given group name.
+
+        Performs a contains search rather than exact match.
+        """
+        security_filter = Filter()
+        security_filter.add_filter('group-name', security_group)
+
+        self._logger.debug('Filters to use: %s', dict(security_filter))
+
+        ec2 = self._get_connection()
+        sec_groups = ec2.get_all_security_groups(filters=dict(security_filter))
+
+        self._logger.info('Found following security groups: %s', sec_groups)
+
+        return sec_groups

--- a/krux_ec2/filter.py
+++ b/krux_ec2/filter.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+#
+# © 2015 Krux Digital, Inc.
+#
+
+#
+# Standard libraries
+#
+
+from __future__ import absolute_import
+
+
+class Filter(object):
+    """
+    Class to represent and handle AWS API's filters.
+
+    You can use this in 3 different ways:
+        1. Pass a dictionary of filter criteria and values to the constructor
+        2. Create an empty filter and add criteria using add_filter or add_tag_filter methods
+        3. Create an empty filter and add creteria from string using parse_string method
+
+    >>> f1 = Filter({'tag:Name': 'example.krxd.net', 'instance-state-name': ['running', 'stopped']})
+
+    >>> f2 = Filter()
+    >>> f2.add_tag_filter('Name', 'example.krxd.net')
+    >>> f2.add_filter('instance-state-name', 'running')
+    >>> f2.add_filter('instance-state-name', 'stopped')
+
+    >>> f3 = Filter()
+    >>> f3.parse_string('tag:Name=example.krxd.net')
+    >>> f3.parse_string('instance-state-name=running')
+    >>> f3.parse_string('instance-state-name=stopped')
+
+    All 3 above filters return a list of items that have 'example.krxd.net' value for the 'Name' tag
+    AND is either 'running' OR 'stopped'.
+    """
+
+    def __init__(self, initial=None):
+        """
+        The initial parameter must be a dictionary of string to a list of values.
+        The key is the filter criteria name, and the value is a list of matches.
+        """
+        if initial is None:
+            self._filter = {}
+        else:
+            self._filter = initial
+
+    def add_filter(self, name, value):
+        """
+        Adds a filter with the given criteria name and value.
+        If there exists a filter with the given criteria, the value is added to the potential match,
+        creating an OR match.
+
+        For filtering via tags, use add_tag_filter.
+        """
+        if name in self._filter:
+            self._filter[name].append(value)
+        else:
+            self._filter.update({name: [value]})
+
+    def add_tag_filter(self, name, value):
+        """
+        Adds a filter with the given tag name and value.
+
+        This is a short cut method for add_filter
+        """
+        self.add_filter('tag:{0}'.format(name), value)
+
+    def parse_string(self, search_term):
+        """
+        Parses the given string to create a filter.
+
+        The string must follow the format "key=value". If "=" is not present in the string,
+        the string is considered as a "tag-value" search. For searching tags, use "tag:Key=value" format.
+        """
+        name = None
+        value = None
+
+        if '=' in search_term:
+            name, value = search_term.split('=', 1)
+        else:
+            name = 'tag-value'
+            value = search_term
+
+        self.add_filter(name, value)
+
+    def __iter__(self):
+        """
+        Override so that dict(Filter) returns the dict to be used by boto.
+        """
+        for key in self._filter:
+            yield key, self._filter[key]

--- a/requirements.pip
+++ b/requirements.pip
@@ -4,6 +4,9 @@
 # Krux-boto library which this is built on
 krux-boto==1.0.1
 
+# For waiting
+retrying==1.3.3
+
 # Transitive libraries
 # This is needed so there are no version conflicts when
 # one downstream library does NOT specify the version it wants,

--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,11 @@ setup(
     packages=find_packages(),
     install_requires=[
         'krux-boto',
+        'retrying',
     ],
     entry_points={
         'console_scripts': [
+            'krux-ec2-test = krux_ec2.cli:main',
         ],
     },
     test_suite='test',

--- a/test/filter_test.py
+++ b/test/filter_test.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+#
+# © 2015 Krux Digital, Inc.
+#
+
+#
+# Standard libraries
+#
+
+from __future__ import absolute_import
+import unittest
+
+#
+# Internal libraries
+#
+
+from krux_ec2.filter import Filter
+
+
+class FilterTest(unittest.TestCase):
+    """
+    Test case for Filter
+    """
+
+    def setUp(self):
+        self.f = Filter()
+
+    def test_init_dict(self):
+        dic = {
+            'tag:Name': 'example.krxd.net',
+            'instance-state-name': ['running', 'stopped']
+        }
+        self.f = Filter(dic)
+
+        self.assertEqual(dic, self.f._filter)
+
+    def test_init_none(self):
+
+        self.assertEqual({}, self.f._filter)
+
+    def test_add_filter_new(self):
+        self.f.add_filter('instance-state-name', 'running')
+        self.assertIn('instance-state-name', self.f._filter)
+        self.assertEqual(['running'], self.f._filter['instance-state-name'])
+
+    def test_add_filter_existing(self):
+        self.f.add_filter('instance-state-name', 'running')
+        self.f.add_filter('instance-state-name', 'stopped')
+        self.assertIn('instance-state-name', self.f._filter)
+        self.assertEqual(['running', 'stopped'], self.f._filter['instance-state-name'])
+
+    def test_add_tag_filter(self):
+        self.f.add_tag_filter('Name', 'example.krxd.net')
+        self.assertIn('tag:Name', self.f._filter)
+        self.assertEqual(['example.krxd.net'], self.f._filter['tag:Name'])
+
+    def test_parse_string_name_value(self):
+        self.f.parse_string('instance-state-name=running')
+        self.assertIn('instance-state-name', self.f._filter)
+        self.assertEqual(['running'], self.f._filter['instance-state-name'])
+
+    def test_parse_string_value(self):
+        self.f.parse_string('example.krxd.net')
+        self.assertIn('tag-value', self.f._filter)
+        self.assertEqual(['example.krxd.net'], self.f._filter['tag-value'])
+
+    def test_iter(self):
+        dic = {
+            'tag:Name': 'example.krxd.net',
+            'instance-state-name': ['running', 'stopped']
+        }
+        self.f = Filter(dic)
+
+        for name, value in self.f:
+            self.assertIn(name, dic)
+            self.assertEqual(value, dic[name])


### PR DESCRIPTION
Thin wrapper for EC2, just like [python-krux-boto-sqs](https://github.com/krux/python-krux-boto-sqs).

98% of the code in `krux_ec2/ec2.py` and `krux_ec2/filter.py` is copy and paste from [python-krux-manage-instance](https://github.com/krux/python-krux-manage-instance/blob/master/krux_ec2/ec2.py), and thus reviewed before.