### PR TITLE
Automatically re-map Elastic IPs when re-spinning instances.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ cover/
 .mr.developer.cfg
 .project
 .pydevproject
+*.swp
 
 # Rope
 .ropeproject

--- a/krux_ec2/ec2.py
+++ b/krux_ec2/ec2.py
@@ -342,3 +342,10 @@ class EC2(object):
         ec2 = self._get_connection()
         elastic_ips = ec2.get_all_addresses()
         return [ip for ip in elastic_ips if ip.instance_id == instance.id]    
+
+    def update_elastic_ip(ip, new_instance):
+        """
+        Updates an Elastic IP to point at the new_instance provided.
+        """
+        ip.disassociate()
+        return ip.associate(instance_id=new_instance.id)

--- a/krux_ec2/ec2.py
+++ b/krux_ec2/ec2.py
@@ -37,7 +37,8 @@ NAME = 'krux-ec2'
 
 @decorator
 def map_search_to_filter(wrapped, *args, **kwargs):
-    """Replace a search argument with an instance of Filter.
+    """
+    Replace a search argument with an instance of Filter.
 
     NOTE: This only works on methods that have a signature that is just
     self and the search criteria; it doesn't pass on kwargs and you can't

--- a/krux_ec2/ec2.py
+++ b/krux_ec2/ec2.py
@@ -11,7 +11,6 @@ from __future__ import absolute_import
 from pprint import pprint
 import re
 import time
-from decorator import decorator
 
 #
 # Third party libraries
@@ -20,6 +19,7 @@ from decorator import decorator
 import boto.ec2
 from boto.ec2.blockdevicemapping import BlockDeviceType, BlockDeviceMapping
 from retrying import retry
+from decorator import decorator
 
 #
 # Internal libraries

--- a/krux_ec2/ec2.py
+++ b/krux_ec2/ec2.py
@@ -192,6 +192,15 @@ class EC2(object):
 
         return instances
 
+    def find_instances_by_hostname(self, hostname):
+        """
+        Helper method for looking up instances by hostname.
+        """
+        return self.ec2.find_instances({
+            'tag:Name': [hostname],
+            'instance-state-name': ['running', 'stopped'],
+        })
+
     def run_instance(self, ami_id, cloud_config, instance_type, sec_group, zone):
         """
         Starts an instance in the given AMI.

--- a/krux_ec2/ec2.py
+++ b/krux_ec2/ec2.py
@@ -36,7 +36,7 @@ NAME = 'krux-ec2'
 
 
 @decorator
-def map_search_to_filter(f, *args, **kwargs):
+def map_search_to_filter(wrapped, *args, **kwargs):
     """Replace a search argument with an instance of Filter.
 
     NOTE: This only works on methods that have a signature that is just
@@ -55,7 +55,7 @@ def map_search_to_filter(f, *args, **kwargs):
     else:
         raise NotImplementedError('This method cannot handle parameter of type {0}'.format(type(args[1]).__name__))
 
-    return f(args[0], search_filter)
+    return wrapped(args[0], search_filter)
 
 
 def get_ec2(args=None, logger=None, stats=None):

--- a/requirements.pip
+++ b/requirements.pip
@@ -21,7 +21,7 @@ Sphinx==1.2b1
 Jinja2==2.6
 Pygments==1.6
 docutils==0.10
-kruxstatsd==0.2.2
+kruxstatsd==0.2.4
 statsd==2.0.3
 argparse==1.2.1
 GitPython==0.3.2.RC1

--- a/requirements.pip
+++ b/requirements.pip
@@ -33,3 +33,4 @@ async==0.6.1
 fudge==1.0.3
 gitdb==0.5.4
 smmap==0.8.2
+decorator==4.0.10

--- a/requirements.pip
+++ b/requirements.pip
@@ -6,6 +6,7 @@ krux-boto==1.0.1
 
 # For waiting
 retrying==1.3.3
+decorator==4.0.10
 
 # Transitive libraries
 # This is needed so there are no version conflicts when
@@ -33,4 +34,3 @@ async==0.6.1
 fudge==1.0.3
 gitdb==0.5.4
 smmap==0.8.2
-decorator==4.0.10

--- a/test/ec2_test.py
+++ b/test/ec2_test.py
@@ -1,11 +1,13 @@
 import unittest
 import mock
 
-from krux_ec2.ec2 import EC2
+from krux_ec2.ec2 import EC2, map_search_to_filter
+from krux_ec2.filter import Filter
 from krux_boto import Boto
 
 
-class EC2Test(unittest.TestCase):
+class EC2Tests(unittest.TestCase):
+    """EC2 class"""
     def test_find_elastic_ips_returns_empty_list(self):
         """Ensure empty lists are sent when no IPs match."""
         mocked_boto = Boto()
@@ -29,3 +31,42 @@ class EC2Test(unittest.TestCase):
         instance.id = 'not-me'
 
         self.assertEqual([], ec2.find_elastic_ips(instance)) 
+
+
+class MapSearchToFilterStub(object):
+    """Used below to test the @map_search_to_filter decorator."""
+    @map_search_to_filter
+    def filter_stubs(self, search):
+        self.results = search
+
+
+class MapSearchToFilterDecoratorTests(unittest.TestCase):
+    def setUp(self):
+        self.search_stub = MapSearchToFilterStub()
+
+    def test_map_search_to_filter_passes_filter_without_modification(self):
+        """Ensure passing an instance of Filter is not mutated."""
+        my_filter = Filter({'instance-state-name': ['running']})
+        self.search_stub.filter_stubs(my_filter)
+        self.assertEqual(my_filter, self.search_stub.results)
+
+    def test_map_search_to_filter_handles_a_list(self):
+        """Ensure a list of arg=val pairs is parsed correctly."""
+        search = ['instance-state-name=running']
+        self.search_stub.filter_stubs(search)
+        self.assertEqual(['running'],
+            self.search_stub.results._filter['instance-state-name'])
+
+    def test_map_search_to_filter_handles_dict(self):
+        """Ensure instance of Filter is instantiated with dict passed."""
+        my_filter = {
+            'instance-state-name': ['running']
+        }
+
+        self.search_stub.filter_stubs(my_filter)
+        self.assertEqual(my_filter, self.search_stub.results._filter)
+
+    def test_invalid_argument_raises_error(self):
+        """Make sure NotImplementedError is raised on invalid arguments."""
+        with self.assertRaises(NotImplementedError):
+            self.search_stub.filter_stubs(mock.Mock())

--- a/test/ec2_test.py
+++ b/test/ec2_test.py
@@ -1,0 +1,31 @@
+import unittest
+import mock
+
+from krux_ec2.ec2 import EC2
+from krux_boto import Boto
+
+
+class EC2Test(unittest.TestCase):
+    def test_find_elastic_ips_returns_empty_list(self):
+        """Ensure empty lists are sent when no IPs match."""
+        mocked_boto = Boto()
+
+        ec2 = EC2(mocked_boto, mock.MagicMock(), mock.MagicMock())
+
+        address1 = mock.Mock()
+        address1.instance_id = 'address1'
+
+        address2 = mock.Mock()
+        address2.instance_id = 'address2'
+
+        mocked_ec2 = mock.Mock()
+        mocked_ec2.get_all_addresses = mock.Mock(return_value=[
+            address1, address2
+        ])
+
+        ec2._get_connection = mock.Mock(return_value=mocked_ec2)
+
+        instance = mock.Mock()
+        instance.id = 'not-me'
+
+        self.assertEqual([], ec2.find_elastic_ips(instance)) 

--- a/test/filter_test.py
+++ b/test/filter_test.py
@@ -26,6 +26,7 @@ class FilterTest(unittest.TestCase):
         self.f = Filter()
 
     def test_init_dict(self):
+        """Ensure dict passed to __init__ is initialized."""
         dic = {
             'tag:Name': 'example.krxd.net',
             'instance-state-name': ['running', 'stopped']
@@ -35,36 +36,42 @@ class FilterTest(unittest.TestCase):
         self.assertEqual(dic, self.f._filter)
 
     def test_init_none(self):
-
+        """Ensure that filters are initialized empty."""
         self.assertEqual({}, self.f._filter)
 
     def test_add_filter_new(self):
+        """Make sure Filter.add_filter mutates filter as expected."""
         self.f.add_filter('instance-state-name', 'running')
         self.assertIn('instance-state-name', self.f._filter)
         self.assertEqual(['running'], self.f._filter['instance-state-name'])
 
     def test_add_filter_existing(self):
+        """Make sure Filter.add_filter is an append operation."""
         self.f.add_filter('instance-state-name', 'running')
         self.f.add_filter('instance-state-name', 'stopped')
         self.assertIn('instance-state-name', self.f._filter)
         self.assertEqual(['running', 'stopped'], self.f._filter['instance-state-name'])
 
     def test_add_tag_filter(self):
+        """Make sure Filter.add_tag_filter helper creates the appropriate tag filter."""
         self.f.add_tag_filter('Name', 'example.krxd.net')
         self.assertIn('tag:Name', self.f._filter)
         self.assertEqual(['example.krxd.net'], self.f._filter['tag:Name'])
 
     def test_parse_string_name_value(self):
+        """Make sure Filter.parse_string_name_value parses argument names."""
         self.f.parse_string('instance-state-name=running')
         self.assertIn('instance-state-name', self.f._filter)
         self.assertEqual(['running'], self.f._filter['instance-state-name'])
 
     def test_parse_string_value(self):
+        """Make sure Filter.parse_string_name_value parses argument values."""
         self.f.parse_string('example.krxd.net')
         self.assertIn('tag-value', self.f._filter)
         self.assertEqual(['example.krxd.net'], self.f._filter['tag-value'])
 
     def test_iter(self):
+        """Make sure Filter objects are iterable."""
         dic = {
             'tag:Name': 'example.krxd.net',
             'instance-state-name': ['running', 'stopped']


### PR DESCRIPTION
#### What's this PR do?

This PR adds a management function for finding Elastic IPs mapped to a given instance as well as a helper for updating an Elastic IP to point at a new instance.

#### Where should the reviewer start?

Start with the following functions:

* `find_instances_by_hostname`
* `find_elastic_ips`
* `update_elastic_ip`

#### How should this be manually tested?

This technically can't be tested manually until https://github.com/krux/python-krux-manage-instance/pull/56 is merged in. However, you can run the tests and take a look at those. Until something consumes this code, though, it can't really be tested.

#### Any background context you want to provide?

@dcrampton said we had to manage Elastic IPs manually on re-spin and I figured I'd give him an early birthday present.

#### What are the relevant tickets?

[PE-2136](https://kruxdigital.jira.com/browse/PE-2136)

#### Screenshots (if appropriate)

n/a

#### What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/13t2zJOexYVAS4/giphy.gif)

#### Definition of Done:
- [x] Is there appropriate test coverage?
- [x] Does this PR require a regression test? All fixes require a regression test.
- [x] Does the [wiki](https://kruxdigital.jira.com/wiki/) need to be updated?
- [x] Does this add new dependencies? If so, do Puppet or PIP requirements need to be updated?
- [x] Will this feature require a new piece of infrastructure be implemented?
- [x] Are any new services fully managed by Puppet?
- [x] Is there appropriate logging and monitoring included?