### PR TITLE
Adding decorator to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     install_requires=[
         'krux-boto',
         'retrying',
+        'decorator',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
#### What's this PR do?
This PR changes adds [`decorator`](https://pypi.python.org/pypi/decorator) to `install_requires` fields in `setup.py`. This will prevent the users of this library from missing this dependency.

#### How was this PR manually tested?
The change was manually tested on development environment.

#### Any background context you want to provide?
`decorator` dependency was added in v0.0.3. [`krux-manage-instance`](https://github.com/krux/python-krux-manage-instance) uses this library and had an issue in packaging because of the missing library. This is to prevent that from happening again. While `install_requires` is known to cause issues, this will at least prevent the application level failure due to missing dependency.