### PR TITLE
Use boto3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Warning
 
-In the current version, `krux_ec2.ec2.EC2` is only compatible with `krux_boto.boto.Boto` object. Passing other objects, such as `krux_boto.boto.Boto3`, will cause an exception.
+`krux_ec2.ec2.EC2` is only compatible with `krux_boto.boto.Boto3` object. Passing other objects, such as `krux_boto.boto.Boto`, will cause an exception.
 
 ## Application quick start
 
@@ -24,13 +24,15 @@ class Application(krux_ec2.cli.Application):
             'tag:Name': 'example.krxd.net',
             'instance-state-name': ['running', 'stopped'],
         })
-        print self.ec2.find_instances(f)
+        print(self.ec2.find_instances(f))
+
 
 def main():
     # The name must be unique to the organization.
     app = Application(name='krux-my-ec2-script')
     with app.context():
         app.run()
+
 
 # Run the application stand alone
 if __name__ == '__main__':
@@ -88,8 +90,8 @@ class MyApplication(object):
             'tag:Name': 'example.krxd.net',
             'instance-state-name': ['running', 'stopped'],
         })
-        print self.ec2.find_instances(f)
+        print(self.ec2.find_instances(f))
 
 ```
 
-As long as you get an instance of `krux_boto.boto.Boto`, the rest are the same. Refer to `krux_boto` module's [README](https://github.com/krux/python-krux-boto/blob/master/README.md) on various ways to instanciate the class.
+As long as you get an instance of `krux_boto.boto.Boto`, the rest are the same. Refer to `krux_boto` module's [README](https://github.com/krux/python-krux-boto/blob/master/README.md) on various ways to instantiate the class.

--- a/dev-requirements.pip
+++ b/dev-requirements.pip
@@ -2,12 +2,17 @@
 -r requirements.pip
 
 # For unit tests
-# GOTCHA: Coverage is pegged at the latest version of 3, because of the error it throw when detemining
-# branch coverage.
-coverage==3.7.1
-# GOTCHA: This is the last version we can build in Jenkins due to the setuptools version limit.
-mock==1.1.2
+coverage==4.2
+# GOTCHA: Make sure this is installed with the latest version of pip. With pip < 1.5, you will run into following error:
+# `error in setup command: Error parsing /data/jenkins/workspace/python-krux-boto-pull-request/.ci.virtualenv/build/mock/setup.cfg: SyntaxError: '<' operator not allowed in environment markers`
+mock==2.0.0
 nose==1.3.7
 
-# Transitive Dependencies
-funcsigs==0.4
+# Transitive libraries
+# This is needed so there are no version conflicts when
+# one downstream library does NOT specify the version it wants,
+# and another one does.
+
+# From mock
+funcsigs==1.0.2
+pbr==1.10.0

--- a/krux_ec2/cli.py
+++ b/krux_ec2/cli.py
@@ -37,7 +37,7 @@ class Application(krux_boto.cli.Application):
             'tag:Name': ['cc001.krxd.net'],
             'instance-state-name': ['running', 'stopped'],
         })
-        print(self.ec2.find_instances(f))
+        self.ec2.find_instances(f)
 
 
 def main():

--- a/krux_ec2/cli.py
+++ b/krux_ec2/cli.py
@@ -8,13 +8,11 @@
 #
 
 from __future__ import absolute_import
-import os
 
 #
 # Internal libraries
 #
 
-from krux.cli import get_group
 import krux_boto.cli
 from krux_ec2.ec2 import add_ec2_cli_arguments, get_ec2, NAME
 from krux_ec2.filter import Filter
@@ -36,10 +34,10 @@ class Application(krux_boto.cli.Application):
 
     def run(self):
         f = Filter({
-            'tag:Name': 'cc001.krxd.net',
+            'tag:Name': ['cc001.krxd.net'],
             'instance-state-name': ['running', 'stopped'],
         })
-        print self.ec2.find_instances(f)
+        print(self.ec2.find_instances(f))
 
 
 def main():

--- a/krux_ec2/ec2.py
+++ b/krux_ec2/ec2.py
@@ -24,6 +24,7 @@ from krux.logging import get_logger
 from krux.stats import get_stats
 from krux.cli import get_parser, get_group
 from krux_ec2.filter import Filter
+from krux.object import Object
 
 
 NAME = 'krux-ec2'
@@ -108,7 +109,7 @@ def add_ec2_cli_arguments(parser, include_boto_arguments=True):
     group = get_group(parser, NAME)
 
 
-class EC2(object):
+class EC2(Object):
     """
     A manager to handle all EC2 related functions.
     Each instance is locked to a connection to a designated region (self.boto.cli_region).
@@ -131,13 +132,10 @@ class EC2(object):
         logger=None,
         stats=None,
     ):
-        # Private variables, not to be used outside this module
-        self._name = NAME
-        self._logger = logger or get_logger(self._name)
-        self._stats = stats or get_stats(prefix=self._name)
+        # Call to the superclass to bootstrap.
+        super(EC2, self).__init__(name=NAME, logger=logger, stats=stats)
 
         # Throw exception when Boto3 is not used
-        # TODO: Start using Boto3 and reverse this check
         if not isinstance(boto, Boto3):
             raise TypeError('krux_ec2.ec2.EC2 only supports krux_boto.boto.Boto3')
 

--- a/krux_ec2/ec2.py
+++ b/krux_ec2/ec2.py
@@ -35,10 +35,20 @@ def map_search_to_filter(wrapped, *args, **kwargs):
     """
     Replace a search argument with an instance of Filter.
 
-    NOTE: This only works on methods that have a signature that is just
-    self and the search criteria; it doesn't pass on kwargs and you can't
-    mangle args as it's a tuple.
+    .. note::
+        This only works on methods that have a signature that is just
+        self and the search criteria; it doesn't pass on kwargs and you can't
+        mangle args as it's a tuple.
+
+    :param wrapped: Function that is wrapped by this decorator
+    :type wrapped: function
+    :param args: Ordered arguments of `wrapped`. The 2nd argument is modified as :py:class:`krux_ec2.filter.Filter`.
+                 The 3rd argument and forward are discarded.
+    :type args: list
+    :param kwargs: Keyword arguments of `wrapped`. Discarded completely.
+    :type kwargs: dict
     """
+    # TODO: Update this to allow other arguments
     search_filter = None
     if isinstance(args[1], list):
         search_filter = Filter()

--- a/krux_ec2/ec2.py
+++ b/krux_ec2/ec2.py
@@ -239,8 +239,7 @@ class EC2(Object):
         instance = instances[0]
         self._logger.debug('Waiting for the instance %s to be ready...', instance.id)
 
-        waiter = self._get_client().get_waiter('instance_running')
-        waiter.wait(InstanceIds=[instance.id])
+        instance.wait_until_running()
         instance.reload()
 
         self._logger.info('Started instance %s', instance.public_dns_name)

--- a/krux_ec2/ec2.py
+++ b/krux_ec2/ec2.py
@@ -370,5 +370,4 @@ class EC2(object):
         """
         Updates an Elastic IP to point at the new_instance provided.
         """
-        #address.disassociate()
         return address.associate(InstanceId=new_instance.id)

--- a/requirements.pip
+++ b/requirements.pip
@@ -4,8 +4,7 @@
 # Krux-boto library which this is built on
 krux-boto==1.2.0
 
-# For waiting
-retrying==1.3.3
+# For decorators
 decorator==4.0.10
 
 # Transitive libraries

--- a/requirements.pip
+++ b/requirements.pip
@@ -2,7 +2,7 @@
 --extra-index-url https://staticfiles.krxd.net/foss/pypi/
 
 # Krux-boto library which this is built on
-krux-boto==1.0.1
+krux-boto==1.2.0
 
 # For waiting
 retrying==1.3.3
@@ -14,23 +14,34 @@ decorator==4.0.10
 # and another one does.
 
 # From krux-boto
-krux-stdlib==2.1.1
-boto==2.39.0
-boto3==1.2.3
+krux-stdlib==2.4.0
+boto==2.42.0
+boto3==1.4.0
+enum34==1.1.6
+six==1.10.0
 pystache==0.5.4
-Sphinx==1.2b1
-Jinja2==2.6
-Pygments==1.6
-docutils==0.10
-kruxstatsd==0.2.4
-statsd==2.0.3
-argparse==1.2.1
-GitPython==0.3.2.RC1
-simplejson==3.3.0
+Sphinx==1.4.6
+kruxstatsd==0.3.0
+argparse==1.4.0
 tornado==3.0.1
-lockfile==0.9.1
+simplejson==3.8.2
+GitPython==2.0.8
+lockfile==0.12.2
 subprocess32==3.2.7
-async==0.6.1
-fudge==1.0.3
-gitdb==0.5.4
-smmap==0.8.2
+Jinja2==2.8
+MarkupSafe==0.23
+Pygments==2.1.3
+alabaster==0.7.9
+babel==2.3.4
+docutils==0.12
+imagesize==0.7.1
+pytz==2016.6.1
+snowballstemmer==1.2.1
+statsd==3.2.1
+gitdb==0.6.4
+smmap==0.9.0
+botocore==1.4.58
+futures==3.0.5
+jmespath==0.9.0
+python-dateutil==2.5.3
+s3transfer==0.1.5

--- a/requirements.pip
+++ b/requirements.pip
@@ -7,6 +7,9 @@ krux-boto==1.2.0
 # For decorators
 decorator==4.0.10
 
+# For Python 3 compatibility
+six==1.10.0
+
 # Transitive libraries
 # This is needed so there are no version conflicts when
 # one downstream library does NOT specify the version it wants,
@@ -17,7 +20,6 @@ krux-stdlib==2.4.0
 boto==2.42.0
 boto3==1.4.0
 enum34==1.1.6
-six==1.10.0
 pystache==0.5.4
 Sphinx==1.4.6
 kruxstatsd==0.3.0

--- a/setup.py
+++ b/setup.py
@@ -45,5 +45,10 @@ setup(
             'krux-ec2-test = krux_ec2.cli:main',
         ],
     },
+    tests_require=[
+        'coverage',
+        'mock',
+        'nose',
+    ],
     test_suite='test',
 )

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     install_requires=[
         'krux-boto',
         'decorator',
+        'six',
     ],
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 from setuptools import setup, find_packages
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION = '0.0.3'
+VERSION = '0.1.0'
 
 # URL to the repository on Github.
 REPO_URL = 'https://github.com/krux/python-krux-boto-ec2'

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
     packages=find_packages(),
     install_requires=[
         'krux-boto',
-        'retrying',
         'decorator',
     ],
     entry_points={

--- a/test/ec2_test.py
+++ b/test/ec2_test.py
@@ -322,7 +322,6 @@ class MapSearchToFilterStub(object):
         self.results = search
 
 
-@unittest.skip
 class MapSearchToFilterDecoratorTests(unittest.TestCase):
     def setUp(self):
         self.search_stub = MapSearchToFilterStub()
@@ -352,4 +351,4 @@ class MapSearchToFilterDecoratorTests(unittest.TestCase):
     def test_invalid_argument_raises_error(self):
         """Make sure NotImplementedError is raised on invalid arguments."""
         with self.assertRaises(NotImplementedError):
-            self.search_stub.filter_stubs(mock.Mock())
+            self.search_stub.filter_stubs(MagicMock())

--- a/test/filter_test.py
+++ b/test/filter_test.py
@@ -26,9 +26,11 @@ class FilterTest(unittest.TestCase):
         self.f = Filter()
 
     def test_init_dict(self):
-        """Ensure dict passed to __init__ is initialized."""
+        """
+        Ensure dict passed to __init__ is initialized.
+        """
         dic = {
-            'tag:Name': 'example.krxd.net',
+            'tag:Name': ['example.krxd.net'],
             'instance-state-name': ['running', 'stopped']
         }
         self.f = Filter(dic)
@@ -36,48 +38,84 @@ class FilterTest(unittest.TestCase):
         self.assertEqual(dic, self.f._filter)
 
     def test_init_none(self):
-        """Ensure that filters are initialized empty."""
+        """
+        Ensure that filters are initialized empty.
+        """
         self.assertEqual({}, self.f._filter)
 
     def test_add_filter_new(self):
-        """Make sure Filter.add_filter mutates filter as expected."""
+        """
+        Make sure Filter.add_filter mutates filter as expected.
+        """
         self.f.add_filter('instance-state-name', 'running')
         self.assertIn('instance-state-name', self.f._filter)
         self.assertEqual(['running'], self.f._filter['instance-state-name'])
 
     def test_add_filter_existing(self):
-        """Make sure Filter.add_filter is an append operation."""
+        """
+        Make sure Filter.add_filter is an append operation.
+        """
         self.f.add_filter('instance-state-name', 'running')
         self.f.add_filter('instance-state-name', 'stopped')
         self.assertIn('instance-state-name', self.f._filter)
         self.assertEqual(['running', 'stopped'], self.f._filter['instance-state-name'])
 
     def test_add_tag_filter(self):
-        """Make sure Filter.add_tag_filter helper creates the appropriate tag filter."""
+        """
+        Make sure Filter.add_tag_filter helper creates the appropriate tag filter.
+        """
         self.f.add_tag_filter('Name', 'example.krxd.net')
         self.assertIn('tag:Name', self.f._filter)
         self.assertEqual(['example.krxd.net'], self.f._filter['tag:Name'])
 
     def test_parse_string_name_value(self):
-        """Make sure Filter.parse_string_name_value parses argument names."""
+        """
+        Make sure Filter.parse_string_name_value parses argument names.
+        """
         self.f.parse_string('instance-state-name=running')
         self.assertIn('instance-state-name', self.f._filter)
         self.assertEqual(['running'], self.f._filter['instance-state-name'])
 
     def test_parse_string_value(self):
-        """Make sure Filter.parse_string_name_value parses argument values."""
+        """
+        Make sure Filter.parse_string_name_value parses argument values.
+        """
         self.f.parse_string('example.krxd.net')
         self.assertIn('tag-value', self.f._filter)
         self.assertEqual(['example.krxd.net'], self.f._filter['tag-value'])
 
-    def test_iter(self):
-        """Make sure Filter objects are iterable."""
-        dic = {
-            'tag:Name': 'example.krxd.net',
-            'instance-state-name': ['running', 'stopped']
-        }
-        self.f = Filter(dic)
+    def test_get(self):
+        """
+        Make sure Filter attributes are accessible via ['name'] notation
+        """
+        self.f.add_filter('instance-state-name', 'running')
+        self.assertEqual(['running'], self.f['instance-state-name'])
 
-        for name, value in self.f:
-            self.assertIn(name, dic)
-            self.assertEqual(value, dic[name])
+    def test_set(self):
+        """
+        Make sure Filter attributes can be set via ['name'] notation
+        """
+        self.f['instance-state-name'] = ['running']
+        self.assertEqual(['running'], self.f['instance-state-name'])
+
+    def test_del(self):
+        """
+        Make sure Filter attributes can be deleted via ['name'] notation
+        """
+        self.f.add_filter('instance-state-name', 'running')
+        del self.f['instance-state-name']
+        self.assertNotIn('instance-state-name', self.f._filter)
+
+    def test_iter(self):
+        """
+        Make sure Filter attributes can be iterated
+        """
+        self.f.add_filter('instance-state-name', 'running')
+        self.assertEqual(['instance-state-name'], [key for key in self.f])
+
+    def test_len(self):
+        """
+        Make sure Filter handles len() properly
+        """
+        self.f.add_filter('instance-state-name', 'running')
+        self.assertEqual(1, len(self.f))

--- a/test/filter_test.py
+++ b/test/filter_test.py
@@ -21,6 +21,14 @@ class FilterTest(unittest.TestCase):
     """
     Test case for Filter
     """
+    TEST_TAG_KEY = 'Name'
+    TEST_TAG_KEY_FULL = 'tag:' + TEST_TAG_KEY
+    TEST_TAG_VALUE = 'example.krxd.net'
+    TEST_FILTER_KEY = 'instance-state-name'
+    TEST_FILTER_VALUE_1 = 'running'
+    TEST_FILTER_VALUE_2 = 'stopped'
+    TEST_FILTER_VALUE = [TEST_FILTER_VALUE_1, TEST_FILTER_VALUE_2]
+    TEST_FILTER_STR = TEST_FILTER_KEY + '=' + TEST_FILTER_VALUE_1
 
     def setUp(self):
         self.f = Filter()
@@ -30,92 +38,85 @@ class FilterTest(unittest.TestCase):
         Ensure dict passed to __init__ is initialized.
         """
         dic = {
-            'tag:Name': ['example.krxd.net'],
-            'instance-state-name': ['running', 'stopped']
+            self.TEST_TAG_KEY_FULL: [self.TEST_TAG_VALUE],
+            self.TEST_FILTER_KEY: self.TEST_FILTER_VALUE,
         }
         self.f = Filter(dic)
 
-        self.assertEqual(dic, self.f._filter)
+        self.assertEqual(dic, self.f)
 
     def test_init_none(self):
         """
         Ensure that filters are initialized empty.
         """
-        self.assertEqual({}, self.f._filter)
+        self.assertEqual({}, self.f)
 
     def test_add_filter_new(self):
         """
         Make sure Filter.add_filter mutates filter as expected.
         """
-        self.f.add_filter('instance-state-name', 'running')
-        self.assertIn('instance-state-name', self.f._filter)
-        self.assertEqual(['running'], self.f._filter['instance-state-name'])
+        self.f.add_filter(self.TEST_FILTER_KEY, self.TEST_FILTER_VALUE_1)
+        self.assertIn(self.TEST_FILTER_KEY, self.f)
+        self.assertEqual([self.TEST_FILTER_VALUE_1], self.f[self.TEST_FILTER_KEY])
 
     def test_add_filter_existing(self):
         """
         Make sure Filter.add_filter is an append operation.
         """
-        self.f.add_filter('instance-state-name', 'running')
-        self.f.add_filter('instance-state-name', 'stopped')
-        self.assertIn('instance-state-name', self.f._filter)
-        self.assertEqual(['running', 'stopped'], self.f._filter['instance-state-name'])
+        self.f.add_filter(self.TEST_FILTER_KEY, self.TEST_FILTER_VALUE_1)
+        self.f.add_filter(self.TEST_FILTER_KEY, self.TEST_FILTER_VALUE_2)
+        self.assertIn(self.TEST_FILTER_KEY, self.f)
+        self.assertEqual(self.TEST_FILTER_VALUE, self.f[self.TEST_FILTER_KEY])
 
     def test_add_tag_filter(self):
         """
         Make sure Filter.add_tag_filter helper creates the appropriate tag filter.
         """
-        self.f.add_tag_filter('Name', 'example.krxd.net')
-        self.assertIn('tag:Name', self.f._filter)
-        self.assertEqual(['example.krxd.net'], self.f._filter['tag:Name'])
+        self.f.add_tag_filter(self.TEST_TAG_KEY, self.TEST_TAG_VALUE)
+        self.assertIn(self.TEST_TAG_KEY_FULL, self.f)
+        self.assertEqual([self.TEST_TAG_VALUE], self.f[self.TEST_TAG_KEY_FULL])
 
     def test_parse_string_name_value(self):
         """
         Make sure Filter.parse_string_name_value parses argument names.
         """
-        self.f.parse_string('instance-state-name=running')
-        self.assertIn('instance-state-name', self.f._filter)
-        self.assertEqual(['running'], self.f._filter['instance-state-name'])
+        self.f.parse_string(self.TEST_FILTER_STR)
+        self.assertIn(self.TEST_FILTER_KEY, self.f)
+        self.assertEqual([self.TEST_FILTER_VALUE_1], self.f[self.TEST_FILTER_KEY])
 
     def test_parse_string_value(self):
         """
         Make sure Filter.parse_string_name_value parses argument values.
         """
-        self.f.parse_string('example.krxd.net')
+        self.f.parse_string(self.TEST_TAG_VALUE)
         self.assertIn('tag-value', self.f._filter)
-        self.assertEqual(['example.krxd.net'], self.f._filter['tag-value'])
-
-    def test_get(self):
-        """
-        Make sure Filter attributes are accessible via ['name'] notation
-        """
-        self.f.add_filter('instance-state-name', 'running')
-        self.assertEqual(['running'], self.f['instance-state-name'])
+        self.assertEqual([self.TEST_TAG_VALUE], self.f._filter['tag-value'])
 
     def test_set(self):
         """
         Make sure Filter attributes can be set via ['name'] notation
         """
-        self.f['instance-state-name'] = ['running']
-        self.assertEqual(['running'], self.f['instance-state-name'])
+        self.f[self.TEST_FILTER_KEY] = self.TEST_FILTER_VALUE
+        self.assertEqual(self.TEST_FILTER_VALUE, self.f[self.TEST_FILTER_KEY])
 
     def test_del(self):
         """
         Make sure Filter attributes can be deleted via ['name'] notation
         """
-        self.f.add_filter('instance-state-name', 'running')
-        del self.f['instance-state-name']
-        self.assertNotIn('instance-state-name', self.f._filter)
+        self.f.add_filter(self.TEST_FILTER_KEY, self.TEST_FILTER_VALUE_1)
+        del self.f[self.TEST_FILTER_KEY]
+        self.assertNotIn(self.TEST_FILTER_KEY, self.f._filter)
 
     def test_iter(self):
         """
         Make sure Filter attributes can be iterated
         """
-        self.f.add_filter('instance-state-name', 'running')
-        self.assertEqual(['instance-state-name'], [key for key in self.f])
+        self.f.add_filter(self.TEST_FILTER_KEY, self.TEST_FILTER_VALUE_1)
+        self.assertEqual([self.TEST_FILTER_KEY], [key for key in self.f])
 
     def test_len(self):
         """
         Make sure Filter handles len() properly
         """
-        self.f.add_filter('instance-state-name', 'running')
+        self.f.add_filter(self.TEST_FILTER_KEY, self.TEST_FILTER_VALUE_1)
         self.assertEqual(1, len(self.f))


### PR DESCRIPTION
## What does this PR do?
This PR is a major refactoring of this branch to make it use Boto3

## Why is this change being made?
Boto3 should replace Boto2.

## Where should the reviewer start?
`krux_ec2/ec2.py`

## How was this tested? How can the reviewer verify your testing?
This was tested in the development environment and through unit tests.

## Completion checklist

- [x] The pull request has been appropriately labelled according to
  our [conventions](https://kruxdigital.jira.com/wiki/display/EN/Changes+and+Peer+Review)
- [x] Dependencies have been documented, deployed, and verified as
      appropriate.
- [x] Use `krux.object.Object`.
- [x] Decommission use of `client`s and replace the `waiter`s with `resource`'s built in [waiting functions](https://boto3.readthedocs.io/en/stable/reference/services/ec2.html#EC2.Instance.wait_until_exists)
- [x] Allow `*args` and `**kwargs` in methods so that the extra arguments can be passed to boto functions.
- [x] The change has unit & integration tests as appropriate.
- [x] Readme has been updated.
- [x] Complete docstring update.
- [x] Stakeholders have been notified. Workflow-impacting changes have
      been appropriately socialized to avoid surprises.
