### PR TITLE
get_tags()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ cover/
 
 # Sphinx documentation
 docs/_build/
+
+# JetBrain IDE settings
+.idea/

--- a/krux_ec2/ec2.py
+++ b/krux_ec2/ec2.py
@@ -310,6 +310,27 @@ class EC2(Object):
 
         return instance
 
+    @staticmethod
+    def get_tags(instance_tags):
+        result = {}
+        for tag in instance_tags:
+            if isinstance(tag, dict) and 'Key' in tag and 'Value' in tag:
+                key = tag['Key']
+                value = tag['Value']
+            elif hasattr(tag, 'key') and hasattr(tag, 'value'):
+                key = tag.key
+                value = tag.value
+            else:
+                raise TypeError('{type} is not a valid type for a tag', type(tag))
+
+            if key == 's_classes':
+                value = value.split(',')
+
+            result[key] = value
+
+        return result
+
+
     def attach_ebs_volume(
         self,
         instance,

--- a/krux_ec2/ec2.py
+++ b/krux_ec2/ec2.py
@@ -312,6 +312,15 @@ class EC2(Object):
 
     @staticmethod
     def get_tags(instance_tags):
+        """
+        Converts the given list of tags into a single dictionary. If there is any duplicate of keys,
+        the later overwrites the former.
+
+        :param instance_tags: List of tags
+        :type instance_tags: list[dict] | list[EC2.Tag]
+        :return: Dictionary of tags
+        :rtype: dict
+        """
         result = {}
         for tag in instance_tags:
             if isinstance(tag, dict) and 'Key' in tag and 'Value' in tag:

--- a/krux_ec2/ec2.py
+++ b/krux_ec2/ec2.py
@@ -323,7 +323,7 @@ class EC2(Object):
         """
         result = {}
         for tag in instance_tags:
-            if isinstance(tag, dict):
+            if isinstance(tag, dict) and 'Key' in tag and 'Value' in tag:
                 # GOTCHA: This will throw an error if there is no 'Key' or 'Value' in the dictionary.
                 #         That is intentional so that the stacktrace will come back to here.
                 key = tag['Key']
@@ -332,7 +332,7 @@ class EC2(Object):
                 key = tag.key
                 value = tag.value
             else:
-                raise TypeError('{type} is not a valid type for a tag'.format(type=type(tag)))
+                raise ValueError('The {tag} is invalid and/or contains invalid values'.format(tag=tag))
 
             if key == 's_classes':
                 value = value.split(',')

--- a/krux_ec2/ec2.py
+++ b/krux_ec2/ec2.py
@@ -323,14 +323,16 @@ class EC2(Object):
         """
         result = {}
         for tag in instance_tags:
-            if isinstance(tag, dict) and 'Key' in tag and 'Value' in tag:
+            if isinstance(tag, dict):
+                # GOTCHA: This will throw an error if there is no 'Key' or 'Value' in the dictionary.
+                #         That is intentional so that the stacktrace will come back to here.
                 key = tag['Key']
                 value = tag['Value']
             elif hasattr(tag, 'key') and hasattr(tag, 'value'):
                 key = tag.key
                 value = tag.value
             else:
-                raise TypeError('{type} is not a valid type for a tag', type(tag))
+                raise TypeError('{type} is not a valid type for a tag'.format(type=type(tag)))
 
             if key == 's_classes':
                 value = value.split(',')
@@ -338,7 +340,6 @@ class EC2(Object):
             result[key] = value
 
         return result
-
 
     def attach_ebs_volume(
         self,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,11 @@
+[metadata]
+description-file = README.md
+
+[nosetests]
+cover-branches = 1
+cover-html = 1
+cover-inclusive = 1
+cover-package = krux_ec2
+verbosity = 2
+with-coverage = 1
+with-id = 1

--- a/test/ec2_test.py
+++ b/test/ec2_test.py
@@ -203,15 +203,44 @@ class EC2Tests(unittest.TestCase):
         result = EC2.get_tags(self.FAKE_TAGS_TAG)
         self.assertEqual(self.FAKE_TAGS, result)
 
+    def test_get_tags_dict_no_key(self):
+        """
+        EC2.get_tags correctly raises error when no 'Key' key is present in a dictionary
+        """
+        invalid_tag = {'Value': 'foo'}
+        with self.assertRaises(ValueError) as e:
+            EC2.get_tags([invalid_tag])
+
+        self.assertEqual(
+            'The {tag} is invalid and/or contains invalid values'.format(tag=invalid_tag),
+            str(e.exception),
+        )
+
+    def test_get_tags_dict_no_value(self):
+        """
+        EC2.get_tags correctly raises error when no 'Value' key is present in a dictionary
+        """
+        invalid_tag = {'Key': 'foo'}
+        with self.assertRaises(ValueError) as e:
+            EC2.get_tags([invalid_tag])
+
+        self.assertEqual(
+            'The {tag} is invalid and/or contains invalid values'.format(tag=invalid_tag),
+            str(e.exception),
+        )
+
     def test_get_tags_wrong_type(self):
         """
         EC2.get_tags correctly raises error when wrong typed tag is passed
         """
         invalid_tag = 1
-        with self.assertRaises(TypeError) as e:
+        with self.assertRaises(ValueError) as e:
             EC2.get_tags([invalid_tag])
 
-        self.assertEqual('{type} is not a valid type for a tag'.format(type=type(invalid_tag)), str(e.exception))
+        self.assertEqual(
+            'The {tag} is invalid and/or contains invalid values'.format(tag=invalid_tag),
+            str(e.exception),
+        )
 
     def test_attach_ebs_volume(self):
         """

--- a/test/ec2_test.py
+++ b/test/ec2_test.py
@@ -15,6 +15,7 @@ import unittest
 #
 
 from mock import MagicMock, patch, call
+from six import iteritems
 
 #
 # Internal libraries
@@ -45,6 +46,18 @@ class EC2Tests(unittest.TestCase):
     FAKE_VOLUME = MagicMock(
         id='vol-a1b2c3d4',
     )
+    FAKE_TAGS = {
+        'Name': FAKE_HOSTNAME,
+        's_classes': ['s_basic', 's_basic::minimal'],
+    }
+    FAKE_TAGS_DICT = [
+        {'Key': key, 'Value': ','.join(value) if isinstance(value, list) else value}
+        for key, value in iteritems(FAKE_TAGS)
+    ]
+    FAKE_TAGS_TAG = [
+        MagicMock(key=key, value=(','.join(value) if isinstance(value, list) else value))
+        for key, value in iteritems(FAKE_TAGS)
+    ]
 
     _BLOCK_DEVICE_MAP = [{
         'VirtualName': 'ephemeral0',
@@ -175,6 +188,30 @@ class EC2Tests(unittest.TestCase):
         self._logger.info.assert_called_once_with(
             'Started instance %s', self.FAKE_INSTANCE.public_dns_name
         )
+
+    def test_get_tags_dict(self):
+        """
+        EC2.get_tags correctly converts the tags in list[dict] format
+        """
+        result = EC2.get_tags(self.FAKE_TAGS_DICT)
+        self.assertEqual(self.FAKE_TAGS, result)
+
+    def test_get_tags_tags(self):
+        """
+        EC2.get_tags correctly converts the tags in list[EC2.Tag] format
+        """
+        result = EC2.get_tags(self.FAKE_TAGS_TAG)
+        self.assertEqual(self.FAKE_TAGS, result)
+
+    def test_get_tags_wrong_type(self):
+        """
+        EC2.get_tags correctly raises error when wrong typed tag is passed
+        """
+        invalid_tag = 1
+        with self.assertRaises(TypeError) as e:
+            EC2.get_tags([invalid_tag])
+
+        self.assertEqual('{type} is not a valid type for a tag'.format(type=type(invalid_tag)), str(e.exception))
 
     def test_attach_ebs_volume(self):
         """


### PR DESCRIPTION
## What does this PR do?

This PR adds `EC2.get_tags()` static method.
## Why is this change being made?

Boto3's instances have tags as a list of dictionaries. This makes it very difficult to quickly grab the value of a tag. We cannot overwrite `instance.tag` attribute either. Thus, there needs to be a separate method just to handle the conversion.
## How was this tested? How can the reviewer verify your testing?

This was tested in the development environment and through unit tests.
## What gif best describes this PR or how it makes you feel?

![](http://i.giphy.com/BmnbtcKKBGqfS.gif)
