### PR TITLE
Exposing block device mapping as optional argument

### DIFF
--- a/krux_ec2/ec2.py
+++ b/krux_ec2/ec2.py
@@ -354,6 +354,7 @@ class EC2(Object):
         self,
         instance,
         device,
+        type,
         save_on_termination,
         volume_id=None,
         volume_size=None,
@@ -370,6 +371,8 @@ class EC2(Object):
         :type instance: boto3.ec2.Instance
         :param device: Device on the instance to which the EBS volume will be attached to (e.g. /dev/sdf)
         :type device: str
+        :param type: Type of the EBS volume to be attached
+        :type type: str
         :param save_on_termination: Whether to keep the volume even after the instance is terminated
         :type save_on_termination: bool
         :param volume_id: ID of a specific volume to use. If set to none, a new volume with the size of `volume_size`
@@ -388,7 +391,7 @@ class EC2(Object):
             volume = self._get_resource().create_volume(
                 Size=volume_size,
                 AvailabilityZone=instance.placement['AvailabilityZone'],
-                VolumeType='gp2',
+                VolumeType=type,
             )
 
             self._logger.debug('Waiting for the EBS volume %s to be ready...', volume.id)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 from setuptools import setup, find_packages
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION = '0.1.0'
+VERSION = '0.2.0'
 
 # URL to the repository on Github.
 REPO_URL = 'https://github.com/krux/python-krux-boto-ec2'


### PR DESCRIPTION
## What does this PR do?
This PR exposes the block device mapping as an optional argument in `run_instance()`.

## Why is this change being made?
We want an ability to change block device mapping of an instance.

## How was this tested? How can the reviewer verify your testing?
The changes were tested manually on development environment using `krux-manage-instance`.
