### PR TITLE
PE-2244: Proper handling of Elastic IP

### DIFF
--- a/krux_ec2/ec2.py
+++ b/krux_ec2/ec2.py
@@ -488,7 +488,7 @@ class EC2(Object):
 
         return sec_groups
 
-    def find_elastic_ips(self, instance):
+    def find_elastic_ip(self, ip, *args, **kwargs):
         """
         Find the Elastic IP(s) mapped to a given instance.
 
@@ -503,23 +503,37 @@ class EC2(Object):
         .. deprecated:: 0.1.0
             Use `instance.classic_address` instead
 
-        :param instance: Instance whose elastic IPs are returned
-        :type instance: boto3.ec2.Instance
+        :param ip: The public IP of the Elastic IP to search for
+        :type ip: str
+        :param args: Ordered arguments passed directly to boto3.resource.classic_addresses.filter()
+        :type args: list
+        :param kwargs: Keyword arguments passed directly to boto3.resource.classic_addresses.filter()
+        :type kwargs: dict
         :return: List of elastic IPs for the given instance
         :rtype: list[boto3.ec2.ClassicAddress]
         """
-        return instance.classic_address
+        # GOTCHA: Do not use PublicIps parameter here by default because it will cause an exception when
+        #         used with a non-existing IP. Allow users to enter any IPs and return them an empty list
+        #         if no EIP matches it.
+        return [
+            classic_address for classic_address in self._get_resource().classic_addresses.filter(*args, **kwargs)
+            if classic_address.public_ip == ip
+        ]
 
-    def update_elastic_ip(self, address, new_instance):
+    def update_elastic_ip(self, instance, address):
         """
         Updates an Elastic IP to point at the new_instance provided.
 
         .. seealso::
             https://boto3.readthedocs.io/en/stable/reference/services/ec2.html#EC2.ClassicAddress.associate
 
-        :param address: Elastic IP to update
-        :type address: boto3.ec2.ClassicAddress
-        :return: Dictionary containing the Association ID
-        :rtype: dict
+        :param instance: Instance to be associated with the given elastic IP
+        :type instance: boto3.ec2.Instance
+        :param address: Elastic IP to update or None to disassociate the elastic IP
+        :type address: boto3.ec2.ClassicAddress | None
         """
-        return address.associate(InstanceId=new_instance.id)
+        if address is not None:
+            address.associate(InstanceId=instance.id)
+        else:
+            for classic_address in self.find_elastic_ip(instance.classic_address.public_ip):
+                classic_address.disassociate()

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 from setuptools import setup, find_packages
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION = '0.2.0'
+VERSION = '0.2.1'
 
 # URL to the repository on Github.
 REPO_URL = 'https://github.com/krux/python-krux-boto-ec2'

--- a/test/ec2_test.py
+++ b/test/ec2_test.py
@@ -163,7 +163,7 @@ class EC2Tests(unittest.TestCase):
         """
         self._resource.create_instances.return_value = [self.FAKE_INSTANCE]
 
-        instance=self._ec2.run_instance(
+        instance = self._ec2.run_instance(
             ami_id=self.FAKE_AMI_ID,
             cloud_config=self.FAKE_CLOUD_CONFIG,
             instance_type=self.FAKE_INSTANCE_TYPE,
@@ -405,6 +405,7 @@ class EC2Tests(unittest.TestCase):
 
         self.FAKE_ELASTIC_IP.disassociate.assert_called_once_with()
 
+
 class MapSearchToFilterStub(object):
     """Used below to test the @map_search_to_filter decorator."""
     @map_search_to_filter
@@ -426,8 +427,10 @@ class MapSearchToFilterDecoratorTests(unittest.TestCase):
         """Ensure a list of arg=val pairs is parsed correctly."""
         search = ['instance-state-name=running']
         self.search_stub.filter_stubs(search)
-        self.assertEqual(['running'],
-            self.search_stub.results._filter['instance-state-name'])
+        self.assertEqual(
+            ['running'],
+            self.search_stub.results._filter['instance-state-name']
+        )
 
     def test_map_search_to_filter_handles_dict(self):
         """Ensure instance of Filter is instantiated with dict passed."""

--- a/test/ec2_test.py
+++ b/test/ec2_test.py
@@ -35,13 +35,15 @@ class EC2Tests(unittest.TestCase):
     FAKE_ZONE = 'us-east-1a'
     FAKE_DEVICE = '/dev/sdz'
     FAKE_VOLUME_SIZE = 10
+    FAKE_ADDRESS = '127.0.0.1'
+    FAKE_ELASTIC_IP = MagicMock(public_ip=FAKE_ADDRESS)
     FAKE_INSTANCE = MagicMock(
         id='i-a1b2c3d4',
         public_dns_name='ec2-127-0-0-1.compute-1.amazonaws.com',
         placement={
             'AvailabilityZone': FAKE_ZONE,
         },
-        classic_address='127.0.0.1'
+        classic_address=FAKE_ELASTIC_IP
     )
     FAKE_VOLUME = MagicMock(
         id='vol-a1b2c3d4',
@@ -363,23 +365,45 @@ class EC2Tests(unittest.TestCase):
 
     def test_find_elastic_ips(self):
         """
-        EC2.find_ebs_volumes correctly returns the elastic IP of the instance
+        EC2.find_elastic_ips correctly returns the elastic IP of the instance
         """
-        expected = self.FAKE_INSTANCE.classic_address
-        actual = self._ec2.find_elastic_ips(self.FAKE_INSTANCE)
-        self.assertEqual(expected, actual)
+        self._resource.classic_addresses.filter.return_value = [
+            self.FAKE_ELASTIC_IP,
+            MagicMock(public_ip='196.168.0.1'),
+        ]
 
-    def test_update_elastic_ip(self):
+        self.assertEqual([self.FAKE_ELASTIC_IP], self._ec2.find_elastic_ip(self.FAKE_ADDRESS))
+
+    def test_find_elastic_ips_none(self):
+        """
+        EC2.find_elastic_ips correctly returns an empty list if a non-existing IP is given
+        """
+        self._resource.classic_addresses.filter.return_value = [
+            self.FAKE_ELASTIC_IP,
+            MagicMock(public_ip='196.168.0.1'),
+        ]
+
+        self.assertEqual([], self._ec2.find_elastic_ip('255.255.255.255'))
+
+    def test_update_elastic_ip_new(self):
         """
         EC2.update_elastic_ip correctly associates the elastic IP to the new instance
         """
         address = MagicMock()
 
-        result = self._ec2.update_elastic_ip(address, self.FAKE_INSTANCE)
+        self._ec2.update_elastic_ip(self.FAKE_INSTANCE, address)
 
-        self.assertEqual(result, address.associate.return_value)
         address.associate.assert_called_once_with(InstanceId=self.FAKE_INSTANCE.id)
 
+    def test_update_elastic_ip_delete(self):
+        """
+        EC2.update_elastic_ip correctly disassociates all elastic IPs for an instance if None is passed
+        """
+        self._resource.classic_addresses.filter.return_value = [self.FAKE_ELASTIC_IP]
+
+        self._ec2.update_elastic_ip(self.FAKE_INSTANCE, None)
+
+        self.FAKE_ELASTIC_IP.disassociate.assert_called_once_with()
 
 class MapSearchToFilterStub(object):
     """Used below to test the @map_search_to_filter decorator."""


### PR DESCRIPTION
## What does this PR do?
This PR fixes the bug where Elastic IP is not properly identified. This PR also fixes the problem where Elastic IP cannot be removed from the instance.

## Why is this change being made?
This is a bug fix.

## How was this tested? How can the reviewer verify your testing?
The change was tested manually on the development environment and via unit test.

## Where should the reviewer start?
`krux_ec2/ec2.py`
