### PR TITLE
Fixing up attach_ebs_volume()

### DIFF
--- a/krux_ec2/ec2.py
+++ b/krux_ec2/ec2.py
@@ -354,7 +354,7 @@ class EC2(Object):
         self,
         instance,
         device,
-        type,
+        volume_type,
         save_on_termination,
         volume_id=None,
         volume_size=None,
@@ -371,8 +371,8 @@ class EC2(Object):
         :type instance: boto3.ec2.Instance
         :param device: Device on the instance to which the EBS volume will be attached to (e.g. /dev/sdf)
         :type device: str
-        :param type: Type of the EBS volume to be attached
-        :type type: str
+        :param volume_type: Type of the EBS volume to be attached
+        :type volume_type: str
         :param save_on_termination: Whether to keep the volume even after the instance is terminated
         :type save_on_termination: bool
         :param volume_id: ID of a specific volume to use. If set to none, a new volume with the size of `volume_size`
@@ -391,7 +391,7 @@ class EC2(Object):
             volume = self._get_resource().create_volume(
                 Size=volume_size,
                 AvailabilityZone=instance.placement['AvailabilityZone'],
-                VolumeType=type,
+                VolumeType=volume_type,
             )
 
             self._logger.debug('Waiting for the EBS volume %s to be ready...', volume.id)

--- a/krux_ec2/ec2.py
+++ b/krux_ec2/ec2.py
@@ -146,6 +146,7 @@ class EC2(Object):
         'VirtualName': 'ephemeral3',
         'DeviceName': '/dev/sde',
     }]
+    DEFAULT_EBS_TYPE = 'standard'
 
     def __init__(
         self,
@@ -354,10 +355,10 @@ class EC2(Object):
         self,
         instance,
         device,
-        volume_type,
         save_on_termination,
         volume_id=None,
         volume_size=None,
+        volume_type=DEFAULT_EBS_TYPE,
     ):
         """
         Attach a designated EBS volume to the given instance at the given device.
@@ -371,8 +372,6 @@ class EC2(Object):
         :type instance: boto3.ec2.Instance
         :param device: Device on the instance to which the EBS volume will be attached to (e.g. /dev/sdf)
         :type device: str
-        :param volume_type: Type of the EBS volume to be attached
-        :type volume_type: str
         :param save_on_termination: Whether to keep the volume even after the instance is terminated
         :type save_on_termination: bool
         :param volume_id: ID of a specific volume to use. If set to none, a new volume with the size of `volume_size`
@@ -381,6 +380,8 @@ class EC2(Object):
         :param volume_size: Size of a new volume to create. If `volume_id` and `volume_size` are both None, an error
                             is raised.
         :type volume_size: int
+        :param volume_type: Type of the EBS volume to be attached
+        :type volume_type: str
         :return: The newly attached EBS volume
         :rtype: boto3.ec2.Volume
         """

--- a/test/ec2_test.py
+++ b/test/ec2_test.py
@@ -35,6 +35,7 @@ class EC2Tests(unittest.TestCase):
     FAKE_ZONE = 'us-east-1a'
     FAKE_DEVICE = '/dev/sdz'
     FAKE_VOLUME_SIZE = 10
+    FAKE_VOLUME_TYPE = 'gp2'
     FAKE_INSTANCE = MagicMock(
         id='i-a1b2c3d4',
         public_dns_name='ec2-127-0-0-1.compute-1.amazonaws.com',
@@ -253,6 +254,7 @@ class EC2Tests(unittest.TestCase):
             instance=self.FAKE_INSTANCE,
             save_on_termination=False,
             volume_size=self.FAKE_VOLUME_SIZE,
+            volume_type=self.FAKE_VOLUME_TYPE,
         )
 
         self.assertEqual(self.FAKE_VOLUME, volume)
@@ -260,11 +262,12 @@ class EC2Tests(unittest.TestCase):
         self._resource.create_volume.assert_called_once_with(
             Size=self.FAKE_VOLUME_SIZE,
             AvailabilityZone=self.FAKE_ZONE,
-            VolumeType='gp2',
+            VolumeType=self.FAKE_VOLUME_TYPE,
         )
         self.FAKE_VOLUME.reload.assert_called_once_with()
         self.FAKE_VOLUME.attach_to_instance.assert_called_once_with(
-            InstanceId=self.FAKE_INSTANCE.id, Device=self.FAKE_DEVICE
+            InstanceId=self.FAKE_INSTANCE.id,
+            Device=self.FAKE_DEVICE,
         )
         self.FAKE_INSTANCE.modify_attribute.assert_called_once_with(BlockDeviceMappings=[{
             'DeviceName': self.FAKE_DEVICE,
@@ -320,6 +323,7 @@ class EC2Tests(unittest.TestCase):
             instance=self.FAKE_INSTANCE,
             save_on_termination=True,
             volume_size=self.FAKE_VOLUME_SIZE,
+            volume_type=self.FAKE_VOLUME_TYPE,
         )
 
         self.FAKE_INSTANCE.modify_attribute.assert_called_once_with(BlockDeviceMappings=[{


### PR DESCRIPTION
## What does this PR do?
This PR changes the parameter name of `attach_ebs_volume()` so that it won't collide with an existing built-in function. This PR also adds proper unit testing to handle `volume_type` parameter.

## Why is this change being made?
This is a bug fix.

## How was this tested? How can the reviewer verify your testing?
The change is manually tested on the development environment and via unit test.

## Where should the reviewer start?
`krux_ec2/ec2.py`

