### PR TITLE
Add the necessary bits to support spinning an instance into a VPC.

### DIFF
--- a/krux_ec2/ec2.py
+++ b/krux_ec2/ec2.py
@@ -546,6 +546,10 @@ class EC2(Object):
         Returns the VPC security group ID for the given Classic security group name.
         """
         client = self._get_client()
+
+        # @joestump 11/07/2017 We look up VPC security groups using the Name tag because VPC 
+        # security groups are created with TF and use name_prefix. This results in SG names
+        # that have unpredictable suffixes. TF sets the Name tag to a predictable value.
         response = client.describe_security_groups(
             Filters=[
                 {

--- a/krux_ec2/ec2.py
+++ b/krux_ec2/ec2.py
@@ -292,8 +292,10 @@ class EC2(Object):
         :type zone: str
         :param block_device_mappings: Block device mapping of the new instance
         :type block_device_mappings: list[dict]
-        :param vpc_id: ID of the VPC to start this instance in
-        :type vpc_id: str
+        :param vpc_security_group: ID of the VPC to start this instance in
+        :type vpc_security_group: str
+        :param subnet_id: ID of the VPC to start this instance in
+        :type subnet_id: str
         :param args: Ordered arguments passed directly to boto3.resource.create_instances()
         :type args: list
         :param kwargs: Keyword arguments passed directly to boto3.resource.create_instances()

--- a/krux_ec2/ec2.py
+++ b/krux_ec2/ec2.py
@@ -269,7 +269,7 @@ class EC2(Object):
         zone,
         block_device_mappings=DEFAULT_BLOCK_DEVICE_MAP,
         vpc_security_group=None,
-        subnet_id=None
+        subnet_id=None,
         *args,
         **kwargs
     ):

--- a/krux_ec2/ec2.py
+++ b/krux_ec2/ec2.py
@@ -549,19 +549,22 @@ class EC2(Object):
         response = client.describe_security_groups(
             Filters=[
                 {
-                    'Name': 'group-name',
+                    'Name': 'tag-key',
+                    'Values': ['Name']
+                },
+                {
+                    'Name': 'tag-value',
                     'Values': [security_group]
                 },
                 {
                     'Name': 'vpc-id',
                     'Values': [vpc_id]
                 }
-
             ])
 
         try:
             return response['SecurityGroups'][0]['GroupId']
-        except KeyError, IndexError:
+        except (KeyError, IndexError):
             return False
 
     def fetch_subnets(self, vpc_id, zone=None):

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 from setuptools import setup, find_packages
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION = '0.2.1'
+VERSION = '0.2.2'
 
 # URL to the repository on Github.
 REPO_URL = 'https://github.com/krux/python-krux-boto-ec2'

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 from setuptools import setup, find_packages
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION = '0.2.2'
+VERSION = '0.3.0'
 
 # URL to the repository on Github.
 REPO_URL = 'https://github.com/krux/python-krux-boto-ec2'


### PR DESCRIPTION
## What does this PR do?

**NOTE:** Required by https://github.com/krux/python-krux-manage-instance/pull/106

Adds the necessary functionality to our EC2 wrapper for spinning an instance up onto our "bridge" VPCs in the main account.

* Adds a helper method for looking up the security group ID by name based on the Classic security group's name. **NOTE:** This assumes we create "twin" SGs on the VPCs. cc @davewongillies @plathrop-sfdc 
* Refactors how arguments are passed into `create_instances`. When we're spinning up on a VPC, we don't specify `SecurityGroups`. Classic SGs don't work with VPC instances.

## Why is this change being made?

Currently we can only ClassicLink our Classic EC2 instances. We would like to start spinning up instances on the VPC itself. 

## How was this tested? How can the reviewer verify your testing?

See testing notes in the downstream PR.

## Where should the reviewer start?

With the new helper methods. And a double-check on my VPC logic would be good.

## What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/qoxM1gi6i0V9e/giphy.gif)