### PR TITLE
Jo w 6901989 py3

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,11 +1,11 @@
 # Include base requirements
--r requirements.txt
+#-r requirements.txt
 
 # For unit tests
-coverage==4.2
+coverage==4.5.4
 # GOTCHA: Make sure this is installed with the latest version of pip. With pip < 1.5, you will run into following error:
 # `error in setup command: Error parsing /data/jenkins/workspace/python-krux-boto-pull-request/.ci.virtualenv/build/mock/setup.cfg: SyntaxError: '<' operator not allowed in environment markers`
-mock==2.0.0
+mock==3.0.5
 nose==1.3.7
 
 # Transitive libraries
@@ -15,4 +15,4 @@ nose==1.3.7
 
 # From mock
 funcsigs==1.0.2
-pbr==1.10.0
+pbr==5.4.3

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 # Include base requirements
-#-r requirements.txt
+-r requirements.txt
 
 # For unit tests
 coverage==4.5.4

--- a/krux_ec2/ec2.py
+++ b/krux_ec2/ec2.py
@@ -19,13 +19,12 @@ from decorator import decorator
 # Internal libraries
 #
 
-from krux_boto import Boto3, add_boto_cli_arguments
+from krux_boto.boto import get_boto3, add_boto_cli_arguments
 from krux.logging import get_logger
 from krux.stats import get_stats
 from krux.cli import get_parser, get_group
 from krux_ec2.filter import Filter
 from krux.object import Object
-
 
 NAME = 'krux-ec2'
 
@@ -168,7 +167,7 @@ class EC2(Object):
         super(EC2, self).__init__(name=NAME, logger=logger, stats=stats)
 
         # Throw exception when Boto3 is not used
-        if not isinstance(boto, Boto3):
+        if not isinstance(boto, get_boto3):
             raise TypeError('krux_ec2.ec2.EC2 only supports krux_boto.boto.Boto3')
 
         self.boto = boto

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,14 @@
 # Krux' python repo
---extra-index-url https://staticfiles.krxd.net/foss/pypi/
+#--extra-index-url https://staticfiles.krxd.net/foss/pypi/
 
 # Krux-boto library which this is built on
-krux-boto==1.2.0
+krux-boto==1.7.0
 
 # For decorators
-decorator==4.0.10
+decorator==4.4.1
 
 # For Python 3 compatibility
-six==1.10.0
+six==1.13.0
 
 # Transitive libraries
 # This is needed so there are no version conflicts when
@@ -16,33 +16,33 @@ six==1.10.0
 # and another one does.
 
 # From krux-boto
-krux-stdlib==2.4.0
-boto==2.42.0
-boto3==1.4.0
+krux-stdlib==4.0.1
+boto==2.49.0
+boto3==1.10.21
 enum34==1.1.6
 pystache==0.5.4
-Sphinx==1.4.6
-kruxstatsd==0.3.0
+Sphinx==1.8.5
+kruxstatsd==0.3.6
 argparse==1.4.0
-tornado==3.0.1
-simplejson==3.8.2
-GitPython==2.0.8
+tornado==5.1.1
+simplejson==3.17.0
+GitPython==2.1.14
 lockfile==0.12.2
-subprocess32==3.2.7
-Jinja2==2.8
-MarkupSafe==0.23
-Pygments==2.1.3
-alabaster==0.7.9
-babel==2.3.4
-docutils==0.12
-imagesize==0.7.1
-pytz==2016.6.1
-snowballstemmer==1.2.1
-statsd==3.2.1
+subprocess32==3.5.4
+Jinja2==2.10.3
+MarkupSafe==1.1.1
+Pygments==2.4.2
+alabaster==0.7.12
+babel==2.7.0
+docutils==0.15.2
+imagesize==1.1.0
+pytz==2019.3
+snowballstemmer==2.0.0
+statsd==3.3.0
 gitdb==0.6.4
 smmap==0.9.0
-botocore==1.4.58
-futures==3.0.5
-jmespath==0.9.0
-python-dateutil==2.5.3
-s3transfer==0.1.5
+botocore==1.13.21
+futures==3.3.0 ; python_version <= '2.7'
+jmespath==0.9.4
+# python-dateutil==2.8.1
+s3transfer==0.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Krux' python repo
-#--extra-index-url https://staticfiles.krxd.net/foss/pypi/
+--extra-index-url https://staticfiles.krxd.net/foss/pypi/
 
 # Krux-boto library which this is built on
 krux-boto==1.7.0

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 from setuptools import setup, find_packages
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION = '0.4.1'
+VERSION = '0.5.0'
 
 # URL to the repository on Github.
 REPO_URL = 'https://github.com/krux/python-krux-boto-ec2'

--- a/test/ec2_test.py
+++ b/test/ec2_test.py
@@ -23,7 +23,7 @@ from six import iteritems
 
 from krux_ec2.ec2 import EC2, map_search_to_filter
 from krux_ec2.filter import Filter
-from krux_boto import Boto
+from krux_boto.boto import get_boto
 
 
 class EC2Tests(unittest.TestCase):


### PR DESCRIPTION
## What does this PR do?

Security alert against Jinja2 version bump to address.
Other (dev-)requirement version bumps.
Python3 compatibility

## Why is this change being made?

Python2 is going EOL

## How was this tested? How can the reviewer verify your testing?

Python2 and Python3 docker containers for local build environments.

## Where should the reviewer start?

Smallish change.

## What gif best describes this PR or how it makes you feel?

![alt text](https://media.giphy.com/media/3o7abKhOpu0NwenH3O/giphy.gif)