### PR TITLE
W-7007135: Fix bug that makes it impossible to instantiate EC2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ docs/_build/
 
 # JetBrain IDE settings
 .idea/
+/.venv/
+/Pipfile

--- a/krux_ec2/ec2.py
+++ b/krux_ec2/ec2.py
@@ -20,6 +20,7 @@ from decorator import decorator
 #
 
 from krux_boto.boto import get_boto3, add_boto_cli_arguments
+from krux_boto.boto import Boto3
 from krux.logging import get_logger
 from krux.stats import get_stats
 from krux.cli import get_parser, get_group
@@ -167,7 +168,7 @@ class EC2(Object):
         super(EC2, self).__init__(name=NAME, logger=logger, stats=stats)
 
         # Throw exception when Boto3 is not used
-        if not isinstance(boto, get_boto3):
+        if not isinstance(boto, Boto3):
             raise TypeError('krux_ec2.ec2.EC2 only supports krux_boto.boto.Boto3')
 
         self.boto = boto

--- a/test/ec2_test.py
+++ b/test/ec2_test.py
@@ -23,7 +23,7 @@ from six import iteritems
 
 from krux_ec2.ec2 import EC2, map_search_to_filter
 from krux_ec2.filter import Filter
-from krux_boto.boto import get_boto
+from krux_boto.boto import get_boto, get_boto3
 
 
 class EC2Tests(unittest.TestCase):
@@ -101,6 +101,22 @@ class EC2Tests(unittest.TestCase):
         self.assertEqual(self._boto, self._ec2.boto)
         self.assertIsNone(self._ec2._resource)
         self.assertIsNone(self._ec2._client)
+
+    def test_create(self):
+        """
+        EC2() successfully initializes given a Boto3
+        """
+        boto3 = get_boto3()
+        ec2 = EC2(boto3)
+
+    def test_instantiate_boto(self):
+        """
+        EC2 raises exception given Boto (not 3)
+        """
+        boto = get_boto()
+        with self.assertRaises(TypeError):
+            ec2 = EC2(boto)
+
 
     def test_get_resource(self):
         """


### PR DESCRIPTION
## What does this PR do?

Fixes a bug that makes breaks this lib:

```
Python 3.6.8 (default, Nov 19 2019, 13:44:05)
[GCC 4.2.1 Compatible Apple LLVM 11.0.0 (clang-1100.0.33.12)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from krux_ec2.ec2 import EC2
>>> from krux_boto.boto import get_boto3
>>> boto = get_boto3
>>> ec2 = EC2(boto)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/slumos/Projects/python-krux-boto-ec2/krux_ec2/ec2.py", line 170, in __init__
    if not isinstance(boto, get_boto3):
TypeError: isinstance() arg 2 must be a type or tuple of types
>>>
```

Adds a test that instantiates the class under test.

Adds a test that exception is raised when expected.

## Why is this change being made?

[W-7007135: BUG: Can't instantiate krux_boto.ec2.EC2](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B00000078YjNIAU/view)

This is blocking: [W-6902131: Upgrade repo python-krux-fabric to Python 3](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B00000077tusIAA/view)

## How was this tested? How can the reviewer verify your testing?

```
10Dec 12:49:40 ~proj/python-krux-boto-ec2 [slumos-bugfix|=]0% pipenv run nosetests
[...]
#38 EC2() successfully initializes given a Boto3 ... ok
#39 EC2 raises exception given Boto (not 3) ... ok
[...]
Ran 39 tests in 0.449s

OK
```

## Where should the reviewer start?

I don't know why, but `Boto3` was changed to `get_boto3`. I assume it was a typo.

## What gif best describes this PR or how it makes you feel?

![](https://pbs.twimg.com/media/B2WHbGaCEAE-2Wf.jpg)