### PR TITLE
W-5913474 bump version-pin for python-krux-boto

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 --extra-index-url https://staticfiles.krxd.net/foss/pypi/
 
 # Krux-boto library which this is built on
-krux-boto==1.7.0
+krux-boto==1.7.1
 
 # For decorators
 decorator==4.4.1

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 from setuptools import setup, find_packages
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION = '0.5.1'
+VERSION = '0.5.2'
 
 # URL to the repository on Github.
 REPO_URL = 'https://github.com/krux/python-krux-boto-ec2'


### PR DESCRIPTION
## What does this PR do?

_Changes requirements.txt for CI testing with latest python-krux-boto_

## Why is this change being made?

_Validate this repo's CI tests for python-krux-boto security update (no code changes)._

## How does this PR do it?

_requirements.txt update_

## How was this tested? How can the reviewer verify your testing?

_Affects CI tests only, see attached_

## What gif best describes this PR or how it makes you feel?

![lock](https://www.randrsecurity.com/image/cache/catalog/Keys/CYZ7500-x400-550x550.jpg)

## Completion checklist

- [x] The pull request has been appropriately labeled according to
  our [conventions](https://kruxdigital.jira.com/wiki/display/EN/Changes+and+Peer+Review).
- [x] The version of the package has been updated according to [Semantic Versioning](http://semver.org/).
- [x] The change has unit & integration tests as appropriate.
- [x] Documentation is up to date and correct.
- [x] Dependencies are correctly listed under `requirements.pip` and
      are up to date without going over a major version.
- [x] Stakeholders have been notified. Workflow-impacting changes have
      been appropriately socialized to avoid surprises.
- [x] The change is either small or have been canaried in the appropriate environment(s).
